### PR TITLE
macos+web: Stats view

### DIFF
--- a/macos/Typing Analyst.xcodeproj/project.pbxproj
+++ b/macos/Typing Analyst.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "avikalp.Typing-Analyst";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -453,7 +453,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "avikalp.Typing-Analyst";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/macos/Typing Analyst/Models/TypingData.swift
+++ b/macos/Typing Analyst/Models/TypingData.swift
@@ -45,30 +45,14 @@ struct ChunkStats: Encodable {
 
 extension TypingData {
     func toKeyValueData() -> [String: Any]? {
-        guard let data = try? JSONEncoder().encode(self),
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        guard let data = try? encoder.encode(self),
               let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
-              var dictionary = jsonObject as? [String: Any] else {
+              let dictionary = jsonObject as? [String: Any] else {
             return nil
         }
-        // Convert Date objects to milliseconds since epoch
-        for (key, value) in dictionary {
-            if let date = value as? Date {
-                dictionary[key] = Int64(date.timeIntervalSince1970 * 1000)
-            } else if let array = value as? [Any] { // Handle arrays of PerSecondDataPoint
-                var newArray: [[String: Any]] = []
-                for item in array {
-                    if var itemDict = item as? [String: Any] {
-                        for (itemKey, itemValue) in itemDict {
-                            if let itemDate = itemValue as? Date {
-                                itemDict[itemKey] = Int64(itemDate.timeIntervalSince1970 * 1000)
-                            }
-                        }
-                        newArray.append(itemDict)
-                    }
-                }
-                dictionary[key] = newArray
-            }
-        }
+        print("[TypingData/toKeyValueData] \(dictionary) ")
         return dictionary
     }
 }

--- a/macos/Typing Analyst/Models/TypingData.swift
+++ b/macos/Typing Analyst/Models/TypingData.swift
@@ -1,0 +1,74 @@
+//
+//  TypingData.swift
+//  Typing Analyst
+//
+//  Created by Avikalp on 04/01/25.
+//
+
+import Foundation
+
+struct TypingData: Encodable { // Make it Encodable for JSON serialization
+    let start_timestamp: Date
+    let end_timestamp: Date?
+    let application: String
+    let device_id: String?
+    let keyboard_id: String?
+    let locale: String
+    let per_second_data: [PerSecondDataPoint]
+    let chunk_stats: ChunkStats
+}
+
+struct PerSecondDataPoint: Encodable {
+    let timestamp: Date
+    let keystrokes: Int
+    let words: Int
+    let backspaces: Int
+    let accuracy: Double
+    let keyStats: KeyStats
+}
+
+struct KeyStats: Encodable {
+    let alphabets: Int
+    let numbers: Int
+    let symbols: Int
+    let backspaces: Int
+    let modifiers: Int
+}
+
+struct ChunkStats: Encodable {
+    let totalKeystrokes: Int
+    let totalWords: Int
+    let accuracy: Double
+//    let peakSpeed: Int?
+//    let longestStreak: Int?
+}
+
+extension TypingData {
+    func toKeyValueData() -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(self),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
+              var dictionary = jsonObject as? [String: Any] else {
+            return nil
+        }
+        // Convert Date objects to milliseconds since epoch
+        for (key, value) in dictionary {
+            if let date = value as? Date {
+                dictionary[key] = Int64(date.timeIntervalSince1970 * 1000)
+            } else if let array = value as? [Any] { // Handle arrays of PerSecondDataPoint
+                var newArray: [[String: Any]] = []
+                for item in array {
+                    if var itemDict = item as? [String: Any] {
+                        for (itemKey, itemValue) in itemDict {
+                            if let itemDate = itemValue as? Date {
+                                itemDict[itemKey] = Int64(itemDate.timeIntervalSince1970 * 1000)
+                            }
+                        }
+                        newArray.append(itemDict)
+                    }
+                }
+                dictionary[key] = newArray
+            }
+        }
+        return dictionary
+    }
+}

--- a/macos/Typing Analyst/Typing_Analyst.entitlements
+++ b/macos/Typing Analyst/Typing_Analyst.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Typing Analyst/Typing_AnalystApp.swift
+++ b/macos/Typing Analyst/Typing_AnalystApp.swift
@@ -12,10 +12,11 @@ struct Typing_AnalystApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate: AppDelegate
     @State private var preferences: AppPreferences = .load()
     @StateObject var viewModel: ViewModel
+    let typingDataSender = TypingDataSender()
 
     init() {
         let preferences = AppPreferences.load()
-        let viewModel = ViewModel(preferences: preferences)
+        let viewModel = ViewModel(preferences: preferences, typingDataSender: typingDataSender)
         _viewModel = StateObject(wrappedValue: viewModel)
         appDelegate.viewModel = viewModel
     }

--- a/macos/Typing Analyst/Utils/AuthManager.swift
+++ b/macos/Typing Analyst/Utils/AuthManager.swift
@@ -1,0 +1,166 @@
+//
+//  AuthManager.swift
+//  Typing Analyst
+//
+//  Created by Avikalp on 03/01/25.
+//
+
+import AuthenticationServices
+import Foundation
+
+class AuthManager: NSObject { // NSObject is needed for ASWebAuthenticationSessionDelegate
+
+    static let shared = AuthManager() // Singleton instance
+    private override init() {} // Prevent direct instantiation
+    let serverURL = "http://localhost:3000"
+
+    func loginWithEmailAndPassword(email: String, password: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        print("login URL: \(self.serverURL)/api/auth/login")
+        guard let url = URL(string: "\(self.serverURL)/api/auth/login") else { return } // Replace with your API URL
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: String] = ["email": email, "password": password]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                completion(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Invalid response from server"])))
+                return
+            }
+
+            // Extract cookies
+            if let allHeaderFields = httpResponse.allHeaderFields as? [String: String] {
+                let cookies = HTTPCookie.cookies(withResponseHeaderFields: allHeaderFields, for: httpResponse.url!)
+
+                // Store cookies in HTTPCookieStorage
+                let cookieStorage = HTTPCookieStorage.shared
+                for cookie in cookies {
+                    cookieStorage.setCookie(cookie)
+                }
+            }
+            
+            completion(.success(())) // Login successful
+        }.resume()
+    }
+
+    func sendTypingData(data: [String: Any], completion: @escaping (Result<Void, Error>) -> Void) {
+        makeApiRequest(url: URL(string: self.serverURL + "/api/typing-stats")!, data: data, completion: completion)
+    }
+
+    private func makeApiRequest(url: URL, data: [String: Any], completion: @escaping (Result<Void, Error>) -> Void) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let cookies = HTTPCookieStorage.shared.cookies(for: request.url!) {
+            let cookieHeader = HTTPCookie.requestHeaderFields(with: cookies)
+            request.allHTTPHeaderFields = cookieHeader
+        }
+        let body = try? JSONSerialization.data(withJSONObject: data)
+        request.httpBody = body
+
+        URLSession.shared.dataTask(with: request) { dataTask, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                completion(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Invalid response from server"])))
+                return
+            }
+            if (200...299).contains(httpResponse.statusCode) {
+                completion(.success(()))
+                return
+            } else if httpResponse.statusCode == 401 {
+                self.refreshTokens { refreshResult in
+                    switch refreshResult {
+                    case .success():
+                        self.makeApiRequest(url: url, data: data, completion: completion)
+                    case .failure(let refreshError):
+                        completion(.failure(refreshError))
+                    }
+                }
+            } else {
+                completion(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Invalid response from server"])))
+            }
+        }.resume()
+    }
+
+    private func refreshTokens(completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let url = URL(string: self.serverURL + "/api/auth/refresh") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+
+        if let cookies = HTTPCookieStorage.shared.cookies(for: request.url!) {
+            let cookieHeader = HTTPCookie.requestHeaderFields(with: cookies)
+            request.allHTTPHeaderFields = cookieHeader
+        }
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                completion(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Invalid response from server"])))
+                return
+            }
+
+            if (200...299).contains(httpResponse.statusCode) {
+                if let allHeaderFields = httpResponse.allHeaderFields as? [String: String] {
+                    let cookies = HTTPCookie.cookies(withResponseHeaderFields: allHeaderFields, for: httpResponse.url!)
+
+                    let cookieStorage = HTTPCookieStorage.shared
+                    for cookie in cookies {
+                        cookieStorage.setCookie(cookie)
+                    }
+                }
+                completion(.success(()))
+            } else {
+                completion(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Could not refresh token"])))
+            }
+        }.resume()
+    }
+    
+    func logout(completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let url = URL(string: "\(self.serverURL)/api/auth/logout") else { return } // Replace with your API URL
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                completion(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Invalid response from server"])))
+                return
+            }
+
+            // Extract cookies
+            if let allHeaderFields = httpResponse.allHeaderFields as? [String: String] {
+                let cookies = HTTPCookie.cookies(withResponseHeaderFields: allHeaderFields, for: httpResponse.url!)
+
+                // Store cookies in HTTPCookieStorage
+                let cookieStorage = HTTPCookieStorage.shared
+                for cookie in cookies {
+                    cookieStorage.setCookie(cookie)
+                }
+            }
+            
+            completion(.success(())) // Logout successful
+        }.resume()
+    }
+}

--- a/macos/Typing Analyst/Utils/TypingCalculations.swift
+++ b/macos/Typing Analyst/Utils/TypingCalculations.swift
@@ -47,10 +47,14 @@ struct TypingCalculations {
     }
 
     static func calculateAccuracy(from keystrokes: [Keystroke], in timeWindow: TimeInterval) -> Double {
-        guard !keystrokes.isEmpty else { return 100.0 } // 100% if no input
-
         let now = Date()
-        let relevantKeystrokes = keystrokes.filter { now.timeIntervalSince($0.timestamp) <= timeWindow }
+        let startTime = now.addingTimeInterval(-timeWindow)
+        return calculateAccuracyDuring(keystrokes: keystrokes, from: startTime, to: now)
+    }
+        
+    static func calculateAccuracyDuring(keystrokes: [Keystroke], from: Date, to: Date) -> Double {
+        guard !keystrokes.isEmpty else { return 100.0 } // 100% if no input
+        let relevantKeystrokes = keystrokes.filter { to.timeIntervalSince($0.timestamp) <= to.timeIntervalSince(from) }
 
         guard !relevantKeystrokes.isEmpty else { return 100.0 }
 

--- a/macos/Typing Analyst/Utils/TypingDataSender.swift
+++ b/macos/Typing Analyst/Utils/TypingDataSender.swift
@@ -1,0 +1,168 @@
+//
+//  TypingDataSender.swift
+//  Typing Analyst
+//
+//  Created by Avikalp on 04/01/25.
+//
+
+import Foundation
+import AppKit
+
+class TypingDataSender: NSObject {
+    private var lastActivity: Date?
+    private var timer: Timer?
+    private let inactivityInterval: TimeInterval = 10 // 10 seconds
+    private var currentChunkKeystrokes: [Keystroke] = []
+    
+    override init() {
+        super.init()
+    }
+    
+    deinit {
+        timer?.invalidate()
+    }
+    
+    func addKeystrokesToChunk(keystroke: Keystroke) {
+        currentChunkKeystrokes.append(keystroke)
+        resetInactivityTimer()
+    }
+    
+    private func resetInactivityTimer() {
+        lastActivity = Date()
+        timer?.invalidate() // Invalidate existing timer
+        
+        timer = Timer.scheduledTimer(withTimeInterval: inactivityInterval, repeats: false) { [weak self] _ in
+            self?.sendTypingDataToServer()
+        }
+    }
+    
+    private func createTypingDataFromKeystrokes(keystrokes: [Keystroke]) -> TypingData {
+        let startTime = keystrokes.first!.timestamp
+        let endTime = keystrokes.last!.timestamp
+        let chunkStats: ChunkStats = ChunkStats(
+            totalKeystrokes: keystrokes.count,
+            totalWords: keystrokes.filter { $0.characters == " " }.count,
+            accuracy: TypingCalculations.calculateAccuracyDuring(keystrokes: keystrokes, from: startTime, to: endTime)
+        )
+        let perSecondData = groupKeystrokesBySecond(keystrokes: keystrokes)
+        
+        let dataToSend: TypingData = TypingData(
+            start_timestamp: startTime,
+            end_timestamp: endTime,
+            application: "unknown",
+            device_id: "unknown",
+            keyboard_id: "unknown",
+            locale: "en_US",
+            per_second_data: perSecondData,
+            chunk_stats: chunkStats
+        )
+        
+        return dataToSend
+    }
+    
+    func sendTypingDataToServer() {
+        guard !currentChunkKeystrokes.isEmpty else { return }
+        
+        let dataToSend = createTypingDataFromKeystrokes(keystrokes: currentChunkKeystrokes)
+        
+        AuthManager.shared.sendTypingData(data: dataToSend) { result in
+            switch result {
+            case .success():
+                print("Typing data sent successfully")
+                self.currentChunkKeystrokes = [] // Clear current data
+            case .failure(let error):
+                print("Error sending typing data: \(error)")
+                // Handle the error appropriately (e.g., retry, log)
+            }
+        }
+    }
+
+    func groupKeystrokesBySecond(keystrokes: [Keystroke]) -> [PerSecondDataPoint] {
+        guard !keystrokes.isEmpty else { return [] }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss" // Format to group by second
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        var perSecondDataPoints: [PerSecondDataPoint] = []
+        var currentSecondKeystrokes: [Keystroke] = []
+        var currentSecond: String?
+
+        for keystroke in keystrokes.sorted(by: { $0.timestamp < $1.timestamp }) { // Sort keystrokes by time
+            let keystrokeSecond = dateFormatter.string(from: keystroke.timestamp)
+
+            if keystrokeSecond != currentSecond {
+                if let currentSecond = currentSecond, !currentSecondKeystrokes.isEmpty {
+                    let perSecondDataPoint = createPerSecondDataPoint(
+                        timestamp: dateFormatter.date(from: currentSecond)!,
+                        keystrokes: currentSecondKeystrokes
+                    )
+                    perSecondDataPoints.append(perSecondDataPoint)
+                }
+                currentSecond = keystrokeSecond
+                currentSecondKeystrokes = [keystroke]
+            } else {
+                currentSecondKeystrokes.append(keystroke)
+            }
+        }
+
+        // Add the last group
+        if let currentSecond = currentSecond, !currentSecondKeystrokes.isEmpty {
+            let perSecondDataPoint = createPerSecondDataPoint(
+                timestamp: dateFormatter.date(from: currentSecond)!,
+                keystrokes: currentSecondKeystrokes
+            )
+            perSecondDataPoints.append(perSecondDataPoint)
+        }
+
+        return perSecondDataPoints
+    }
+
+    private func createPerSecondDataPoint(timestamp: Date, keystrokes: [Keystroke]) -> PerSecondDataPoint {
+        var keystrokeCount = 0
+        var wordCount = 0
+        var backspaceCount = 0
+        var alphabetCount = 0
+        var numberCount = 0
+        var symbolCount = 0
+        var modifierCount = 0
+
+        for keystroke in keystrokes {
+            keystrokeCount += 1
+
+            if let characters = keystroke.characters {
+                wordCount += characters.split(separator: " ").count
+                for character in characters {
+                    if character.isLetter {
+                        alphabetCount += 1
+                    } else if character.isNumber {
+                        numberCount += 1
+                    } else if character.isSymbol || character.isPunctuation {
+                        symbolCount += 1
+                    }
+                }
+            }
+
+            if keystroke.keyCode == 51 { // Backspace key code
+                backspaceCount += 1
+            }
+
+            modifierCount += keystroke.modifiers.split(separator: "+").count - (keystroke.modifiers == "" ? 0 : 1)
+        }
+        let accuracy = keystrokeCount == 0 ? 100.0 : Double(keystrokeCount - backspaceCount) / Double(keystrokeCount) * 100.0
+        return PerSecondDataPoint(
+            timestamp: timestamp,
+            keystrokes: keystrokeCount,
+            words: wordCount,
+            backspaces: backspaceCount,
+            accuracy: accuracy,
+            keyStats: KeyStats(
+                alphabets: alphabetCount,
+                numbers: numberCount,
+                symbols: symbolCount,
+                backspaces: backspaceCount,
+                modifiers: modifierCount
+            )
+        )
+    }
+}

--- a/macos/Typing Analyst/ViewModel.swift
+++ b/macos/Typing Analyst/ViewModel.swift
@@ -25,9 +25,11 @@ class ViewModel: ObservableObject {
     @Published var cpmData: [(x: Date, y: Double)] = []
     @Published var accuracyData: [(x: Date, y: Double)] = []
     
+    private let typingDataSender: TypingDataSender
 
-    init(preferences: AppPreferences) {
+    init(preferences: AppPreferences, typingDataSender: TypingDataSender) {
         self.preferences = preferences
+        self.typingDataSender = typingDataSender
         startTimer()
     }
 
@@ -52,6 +54,7 @@ class ViewModel: ObservableObject {
     func addKeystroke(keystroke: Keystroke) {
         keystrokes.append(keystroke) // Just append, no need to remove
         update()
+        typingDataSender.addKeystrokesToChunk(keystroke: keystroke)
     }
     
     func update() {

--- a/macos/Typing Analyst/Views/AccountSettingsView.swift
+++ b/macos/Typing Analyst/Views/AccountSettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AccountSettingsView: View {
     @Binding var isLoggedIn: Bool
+    @State private var errorMessage: String? = nil
 
     var body: some View {
         VStack {
@@ -21,10 +22,16 @@ struct AccountSettingsView: View {
                             isLoggedIn = false // Correct: Directly assign to isLoggedIn
                         case .failure(let error):
                             print("Logout failed:", error)
-                            // Handle logout error
+                            errorMessage = error.localizedDescription
                         }
                     }
                 }
+            }
+            .padding(.top)
+            if let errorMessage = errorMessage {
+                Text(errorMessage)
+                    .foregroundColor(.red)
+                    .padding(.bottom)
             }
         }
         .frame(width: 800)

--- a/macos/Typing Analyst/Views/AccountSettingsView.swift
+++ b/macos/Typing Analyst/Views/AccountSettingsView.swift
@@ -1,0 +1,31 @@
+//
+//  AccountSettingsView.swift
+//  Typing Analyst
+//
+//  Created by Avikalp on 03/01/25.
+//
+
+import SwiftUI
+
+struct AccountSettingsView: View {
+    @Binding var isLoggedIn: Bool
+
+    var body: some View {
+        VStack {
+            Text("You are logged in!")
+            Button("Logout") {
+                AuthManager.shared.logout { result in
+                    DispatchQueue.main.async {
+                        switch result {
+                        case .success():
+                            isLoggedIn = false // Correct: Directly assign to isLoggedIn
+                        case .failure(let error):
+                            print("Logout failed:", error)
+                            // Handle logout error
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/macos/Typing Analyst/Views/AccountSettingsView.swift
+++ b/macos/Typing Analyst/Views/AccountSettingsView.swift
@@ -27,5 +27,7 @@ struct AccountSettingsView: View {
                 }
             }
         }
+        .frame(width: 800)
+        .padding(20)
     }
 }

--- a/macos/Typing Analyst/Views/GeneralSettingsView.swift
+++ b/macos/Typing Analyst/Views/GeneralSettingsView.swift
@@ -1,0 +1,73 @@
+//
+//  GeneralSettingsView.swift
+//  Typing Analyst
+//
+//  Created by Avikalp on 03/01/25.
+//
+
+import SwiftUI
+
+struct GeneralSettingsView: View {
+    @Binding var preferences: AppPreferences
+    private let formWidth: CGFloat = 800
+    
+    var body: some View {
+        Form {
+            VStack(spacing: 15) {
+                HStack {
+                    Text("Update Frequency")
+                    Image(systemName: "info.circle")
+                        .help("How often the charts and statistics are updated. Lower values provide more frequent updates but may use more system resources.")
+                    TextField("", value: $preferences.updateFrequency, format: .number)
+                        .multilineTextAlignment(.center)
+                        .frame(width: 100)
+                    Text("seconds")
+                }
+                
+                HStack {
+                    Text("Measurement Time Window")
+                    Image(systemName: "info.circle")
+                        .help("The rolling window of time within which your WPM, CPM and accuracy are measured, i.e. your typing performance of the last X seconds.")
+                    TextField("", value: $preferences.dataTimeWindow, format: .number)
+                        .multilineTextAlignment(.center)
+                        .frame(width: 100)
+                    Text("seconds")
+                }
+                
+                HStack {
+                    Text("Max Chart Time Window")
+                    Image(systemName: "info.circle")
+                        .help("The longest time period shown in the charts. Longer windows show more historical data.")
+                    TextField("", value: $preferences.chartTimeWindow, format: .number)
+                        .multilineTextAlignment(.center)
+                        .frame(width: 100)
+                    Text("seconds")
+                }
+                
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Charts to show in popover")
+                        .font(.headline)
+                        .padding(.top)
+                    
+                    HStack {
+                        Toggle("Show WPM Chart", isOn: $preferences.showWPMChart)
+                        Image(systemName: "info.circle")
+                            .help("Words Per Minute chart shows your typing speed over time")
+                    }
+                    HStack {
+                        Toggle("Show CPM Chart", isOn: $preferences.showCPMChart)
+                        Image(systemName: "info.circle")
+                            .help("Characters Per Minute chart shows your raw typing rate")
+                    }
+                    HStack {
+                        Toggle("Show Accuracy Chart", isOn: $preferences.showAccuracyChart)
+                        Image(systemName: "info.circle")
+                            .help("Accuracy chart shows the percentage of correctly typed characters")
+                    }
+                }
+            }
+            .frame(width: formWidth)
+            .padding()
+        }
+    }
+}

--- a/macos/Typing Analyst/Views/LoginView.swift
+++ b/macos/Typing Analyst/Views/LoginView.swift
@@ -1,0 +1,67 @@
+//
+//  LoginView.swift
+//  Typing Analyst
+//
+//  Created by Avikalp on 03/01/25.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email = ""
+    @State private var password = ""
+    @State private var isLoading = false
+    @State private var errorMessage: String? = nil
+    @Binding var isLoggedIn: Bool
+
+    var body: some View {
+        VStack {
+            Text("Login")
+                .font(.title)
+                .padding(.bottom)
+
+            if let errorMessage = errorMessage {
+                Text(errorMessage)
+                    .foregroundColor(.red)
+                    .padding(.bottom)
+            }
+
+            TextField("Email", text: $email)
+                .textContentType(.emailAddress)
+                .textCase(.lowercase)
+                .padding()
+                .border(Color.gray)
+
+            SecureField("Password", text: $password)
+                .padding()
+                .border(Color.gray)
+
+            Button(action: {
+                isLoading = true
+                errorMessage = nil
+
+                AuthManager.shared.loginWithEmailAndPassword(email: email, password: password) { result in
+                    DispatchQueue.main.async {
+                        isLoading = false
+                        switch result {
+                        case .success(let user):
+                            print("Login successful: \(user)")
+                            isLoggedIn = true
+                        case .failure(let error):
+                            errorMessage = error.localizedDescription
+                            print("Login failed: \(error)")
+                        }
+                    }
+                }
+            }) {
+                if isLoading {
+                    ProgressView()
+                } else {
+                    Text("Login")
+                }
+            }
+            .padding(.top)
+        }
+        .padding()
+    }
+}

--- a/macos/Typing Analyst/Views/PreferencesView.swift
+++ b/macos/Typing Analyst/Views/PreferencesView.swift
@@ -9,65 +9,22 @@ import SwiftUI
 
 struct PreferencesView: View {
     @Binding var preferences: AppPreferences
-    private let formWidth: CGFloat = 800
-
+    @AppStorage("isLoggedIn") private var isLoggedIn = false
+    
     var body: some View {
-        Form {
-            VStack(spacing: 15) {
-                HStack {
-                    Text("Update Frequency")
-                    Image(systemName: "info.circle")
-                        .help("How often the charts and statistics are updated. Lower values provide more frequent updates but may use more system resources.")
-                    TextField("", value: $preferences.updateFrequency, format: .number)
-                        .multilineTextAlignment(.center)
-                        .frame(width: 100)
-                    Text("seconds")
-                }
-
-                HStack {
-                    Text("Measurement Time Window")
-                    Image(systemName: "info.circle")
-                        .help("The rolling window of time within which your WPM, CPM and accuracy are measured, i.e. your typing performance of the last X seconds.")
-                    TextField("", value: $preferences.dataTimeWindow, format: .number)
-                        .multilineTextAlignment(.center)
-                        .frame(width: 100)
-                    Text("seconds")
-                }
-
-                HStack {
-                    Text("Max Chart Time Window")
-                    Image(systemName: "info.circle")
-                        .help("The longest time period shown in the charts. Longer windows show more historical data.")
-                    TextField("", value: $preferences.chartTimeWindow, format: .number)
-                        .multilineTextAlignment(.center)
-                        .frame(width: 100)
-                    Text("seconds")
-                }
-
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Charts to show in popover")
-                        .font(.headline)
-                        .padding(.top)
-
-                    HStack {
-                        Toggle("Show WPM Chart", isOn: $preferences.showWPMChart)
-                        Image(systemName: "info.circle")
-                            .help("Words Per Minute chart shows your typing speed over time")
-                    }
-                    HStack {
-                        Toggle("Show CPM Chart", isOn: $preferences.showCPMChart)
-                        Image(systemName: "info.circle")
-                            .help("Characters Per Minute chart shows your raw typing rate")
-                    }
-                    HStack {
-                        Toggle("Show Accuracy Chart", isOn: $preferences.showAccuracyChart)
-                        Image(systemName: "info.circle")
-                            .help("Accuracy chart shows the percentage of correctly typed characters")
-                    }
-                }
+        TabView {
+            // General Settings tab
+            GeneralSettingsView(preferences: $preferences)
+                .tabItem { Label("General", systemImage: "gear") }
+            
+            if !isLoggedIn {
+                LoginView(isLoggedIn: $isLoggedIn)
+                    .tabItem { Label("Login", systemImage: "lock") }
+            } else {
+                AccountSettingsView(isLoggedIn: $isLoggedIn)
+                    .tabItem { Label("Account", systemImage: "person.crop.circle") }
             }
-            .frame(width: formWidth)
-            .padding()
         }
+        .padding(20)
     }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.47.10",
         "axios": "^1.7.9",
+        "chart.js": "^4.4.7",
         "next": "15.1.3",
         "react": "^19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
@@ -673,6 +675,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "15.1.3",
@@ -1772,6 +1780,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
+      "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -4758,6 +4778,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.47.10",
     "axios": "^1.7.9",
+    "chart.js": "^4.4.7",
     "next": "15.1.3",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {

--- a/web/src/app/api/auth/refresh/route.ts
+++ b/web/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { supabase } from '@/utils/supabaseClient';
+import { cookies } from 'next/headers'; // Import cookies
+
+export async function POST(request: Request) {
+	try {
+		const cookieStore = await cookies();
+		const refreshToken = cookieStore.get('sb-typing-analyst-refresh-token')?.value
+
+		if (!refreshToken) {
+			return NextResponse.json({ error: 'Missing refresh token' }, { status: 400 });
+		}
+
+		const { data, error } = await supabase.auth.refreshSession({ refresh_token: refreshToken });
+
+		if (error) {
+			console.error('Supabase refresh error:', error);
+			return NextResponse.json({ error: error.message }, { status: 401 });
+		}
+
+		const response = NextResponse.json({ message: 'Token refreshed successfully' }, { status: 200 });
+		if (data.session) {
+			response.cookies.set({
+				name: 'sb-typing-analyst-auth',
+				value: data.session.access_token,
+				httpOnly: true,
+				secure: process.env.NODE_ENV === 'production',
+				sameSite: 'strict',
+				path: '/',
+				maxAge: 60 * 60 * 24 * 30, // 30 days
+			});
+			response.cookies.set({
+				name: 'sb-typing-analyst-refresh-token',
+				value: data.session.refresh_token,
+				httpOnly: true,
+				secure: process.env.NODE_ENV === 'production',
+				sameSite: 'strict',
+				path: '/',
+				maxAge: 60 * 60 * 24 * 30, // 30 days
+			});
+		}
+		return response
+	} catch (error) {
+		console.error('Server error:', error);
+		return NextResponse.json({ error: 'An unexpected error occurred.' }, { status: 500 });
+	}
+}

--- a/web/src/app/api/typing-stats/route.ts
+++ b/web/src/app/api/typing-stats/route.ts
@@ -53,3 +53,30 @@ export async function POST(request: Request) {
 		return NextResponse.json({ error: 'Failed to insert data' }, { status: 500 });
 	}
 }
+
+export async function GET(request: Request) {
+	try {
+		// 1. Authenticate the request (using Supabase Auth)
+		const { data: { user } } = await supabase.auth.getUser();
+
+		if (!user) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+		}
+
+		// 2. Fetch the typing statistics for the authenticated user
+		const { data, error } = await supabase
+			.from('typing_stats')
+			.select('*')
+			.eq('user_id', user.id);
+
+		if (error) {
+			console.error('Supabase error:', error);
+			return NextResponse.json({ error: error.message }, { status: 500 });
+		}
+
+		return NextResponse.json({ data }, { status: 200 });
+	} catch (error) {
+		console.error('Server error:', error);
+		return NextResponse.json({ error: 'Failed to fetch data' }, { status: 500 });
+	}
+}

--- a/web/src/app/api/typing-stats/route.ts
+++ b/web/src/app/api/typing-stats/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { supabase } from '@/utils/supabaseClient';
-import { Json } from '../../../database.types';
+import { Json } from '../../../../database.types';
+import { convertTimestampsToISO } from '@/utils/datetime';
 
 type TypingStat = {
-	start_timestamp: string;
-	end_timestamp: string;
+	start_timestamp: number; // milliseconds since epoch
+	end_timestamp: number; // milliseconds since epoch
 	application: string;
 	device_id: string;
 	keyboard_id: string | null;
@@ -38,9 +39,10 @@ export async function POST(request: Request) {
 		}
 
 		// 3. Insert the data into Supabase
+		const dataToInsert = convertTimestampsToISO(typingStats);
 		const { error } = await supabase
 			.from('typing_stats')
-			.insert({ ...typingStats, user_id: user.id });
+			.insert({ ...dataToInsert, user_id: user.id });
 
 		if (error) {
 			console.error('Supabase error:', error);

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
 				setError(response.data.error || 'Login failed.');
 			} else {
 				localStorage.setItem('userId', response.data.userId);
-				window.location.href = '/'; // Redirect to the desired page after successful login
+				window.location.href = '/typing-stats'; // Redirect to the desired page after successful login
 			}
 		} catch (err) {
 			setError('An unexpected error occurred.');

--- a/web/src/app/signup/page.tsx
+++ b/web/src/app/signup/page.tsx
@@ -21,7 +21,7 @@ export default function SignUpPage() {
 				setError(response.data.error || 'Sign up failed.');
 			} else {
 				// Redirect to the desired page after successful login
-				window.location.href = '/'; // Or another route
+				window.location.href = '/typing-stats'; // Or another route
 			}
 		} catch (err) {
 			setError('An unexpected error occurred.');

--- a/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
+++ b/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Line } from "react-chartjs-2";
+import { TypingStat } from "./page";
+
+const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] }> = ({ typingStats }) => {
+	const getAccuracyDataFromTypingStats = (typingStats: TypingStat[]) => ({
+		labels: typingStats.map(stat => new Date(stat.start_timestamp).toLocaleTimeString()),
+		datasets: [
+			{
+				label: 'Accuracy',
+				data: typingStats.map(stat => stat.chunk_stats.accuracy),
+				borderColor: 'rgba(153, 102, 255, 1)',
+				backgroundColor: 'rgba(153, 102, 255, 0.2)',
+			},
+		],
+	});
+
+	const chartData = getAccuracyDataFromTypingStats(typingStats);
+	const options = {
+		scales: {
+			y: {
+				beginAtZero: true,
+			},
+		},
+	};
+	return (
+		<div className='w-full'>
+			<h2>Accuracy</h2>
+			<Line data={chartData} options={options} />
+		</div>
+	);
+}
+
+export default ChunkAccuracyGraph;

--- a/web/src/app/typing-stats/ChunkWPMGraph.tsx
+++ b/web/src/app/typing-stats/ChunkWPMGraph.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Line } from "react-chartjs-2";
+import { TypingStat } from "./page";
+
+const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] }> = ({ typingStats }) => {
+	const getWpmDataFromTypingStats = (typingStats: TypingStat[]) => {
+		return {
+			labels: typingStats.map(stat => new Date(stat.start_timestamp).toLocaleTimeString()),
+			datasets: [
+				{
+					label: 'WPM',
+					data: typingStats.map(stat => stat.chunk_stats.totalWords * 60000 / (new Date(stat.end_timestamp).valueOf() - new Date(stat.start_timestamp).valueOf())),
+					fill: false,
+					borderColor: 'rgba(75, 192, 192, 1)',
+					backgroundColor: 'rgba(75, 192, 192, 0.2)',
+					tension: 0.1,
+				},
+			],
+		}
+	};
+
+	const chartData = getWpmDataFromTypingStats(typingStats);
+	const options = {
+		scales: {
+			y: {
+				beginAtZero: true,
+			},
+		},
+	};
+	return (
+		<div className='w-full'>
+			<h2>Words Per Minute (WPM)</h2>
+			<Line data={chartData} options={options} />
+		</div>
+	);
+}
+
+export default ChunkWPMGraph;

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -28,6 +28,7 @@ const TypingStatsPage: React.FC = () => {
 
 			if (!userId) {
 				setError('Unauthorized');
+				window.location.href = '/login';
 				return;
 			}
 
@@ -40,6 +41,12 @@ const TypingStatsPage: React.FC = () => {
 
 			if (!response.ok) {
 				const errorData = await response.json();
+				if (response.status === 401) {
+					setError('Unauthorized');
+					console.error('Unauthorized: redirecting to login');
+					window.location.href = '/login';
+					return;
+				}
 				setError(errorData.error);
 				return;
 			}

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import 'chart.js/auto';
+
+type TypingStat = {
+	start_timestamp: string;
+	end_timestamp: string;
+	application: string;
+	device_id: string;
+	keyboard_id: string | null;
+	locale: string;
+	per_second_data: any[];
+	chunk_stats: {
+		wpm: number;
+		accuracy: number;
+	};
+};
+
+const TypingStatsPage: React.FC = () => {
+	const [typingStats, setTypingStats] = useState<TypingStat[]>([]);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const fetchTypingStats = async () => {
+			const userId = localStorage.getItem('userId');
+
+			if (!userId) {
+				setError('Unauthorized');
+				return;
+			}
+
+			const response = await fetch('/api/typing-stats', {
+				method: 'GET',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			});
+
+			if (!response.ok) {
+				const errorData = await response.json();
+				setError(errorData.error);
+				return;
+			}
+
+			const data = await response.json();
+			setTypingStats(data.data);
+		};
+
+		fetchTypingStats();
+	}, []);
+
+	const wpmData = {
+		labels: typingStats.map(stat => new Date(stat.start_timestamp).toLocaleDateString()),
+		datasets: [
+			{
+				label: 'WPM',
+				data: typingStats.map(stat => stat.chunk_stats.wpm),
+				borderColor: 'rgba(75, 192, 192, 1)',
+				backgroundColor: 'rgba(75, 192, 192, 0.2)',
+			},
+		],
+	};
+
+	const accuracyData = {
+		labels: typingStats.map(stat => new Date(stat.start_timestamp).toLocaleDateString()),
+		datasets: [
+			{
+				label: 'Accuracy',
+				data: typingStats.map(stat => stat.chunk_stats.accuracy),
+				borderColor: 'rgba(153, 102, 255, 1)',
+				backgroundColor: 'rgba(153, 102, 255, 0.2)',
+			},
+		],
+	};
+
+	if (error) {
+		return <div>Error: {error}</div>;
+	}
+
+	return (
+		<div>
+			<h1>Typing Statistics</h1>
+			<div>
+				<h2>Words Per Minute (WPM)</h2>
+				<Line data={wpmData} />
+			</div>
+			<div>
+				<h2>Accuracy</h2>
+				<Line data={accuracyData} />
+			</div>
+		</div>
+	);
+};
+
+export default TypingStatsPage;

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -3,19 +3,37 @@
 import React, { useEffect, useState } from 'react';
 import { Line } from 'react-chartjs-2';
 import 'chart.js/auto';
+import ChunkWPMGraph from './ChunkWPMGraph';
+import ChunkAccuracyGraph from './ChunkAccuracyGraph';
 
-type TypingStat = {
+export type TypingStat = {
 	start_timestamp: string;
 	end_timestamp: string;
 	application: string;
 	device_id: string;
 	keyboard_id: string | null;
 	locale: string;
-	per_second_data: any[];
+	per_second_data: PerSecondData[];
 	chunk_stats: {
-		wpm: number;
+		totalWords: number;
+		totatKeystrokes: number;
 		accuracy: number;
 	};
+};
+
+export type PerSecondData = {
+	timestamp: string;
+	keystrokes: number;
+	words: number;
+	accuracy: number;
+	backspaces: number;
+	keyStates: {
+		numbers: number;
+		symbols: number;
+		alphabets: number;
+		modifiers: number;
+		backspaces: number;
+	}
 };
 
 const TypingStatsPage: React.FC = () => {
@@ -58,45 +76,15 @@ const TypingStatsPage: React.FC = () => {
 		fetchTypingStats();
 	}, []);
 
-	const wpmData = {
-		labels: typingStats.map(stat => new Date(stat.start_timestamp).toLocaleDateString()),
-		datasets: [
-			{
-				label: 'WPM',
-				data: typingStats.map(stat => stat.chunk_stats.wpm),
-				borderColor: 'rgba(75, 192, 192, 1)',
-				backgroundColor: 'rgba(75, 192, 192, 0.2)',
-			},
-		],
-	};
-
-	const accuracyData = {
-		labels: typingStats.map(stat => new Date(stat.start_timestamp).toLocaleDateString()),
-		datasets: [
-			{
-				label: 'Accuracy',
-				data: typingStats.map(stat => stat.chunk_stats.accuracy),
-				borderColor: 'rgba(153, 102, 255, 1)',
-				backgroundColor: 'rgba(153, 102, 255, 0.2)',
-			},
-		],
-	};
-
 	if (error) {
 		return <div>Error: {error}</div>;
 	}
 
 	return (
-		<div>
+		<div className="flex flex-col items-center justify-items-center min-h-screen gap-16 sm:p-20 font-[family-name:var(--font-space-mono-regular)] bg-background">
 			<h1>Typing Statistics</h1>
-			<div>
-				<h2>Words Per Minute (WPM)</h2>
-				<Line data={wpmData} />
-			</div>
-			<div>
-				<h2>Accuracy</h2>
-				<Line data={accuracyData} />
-			</div>
+			<ChunkWPMGraph typingStats={typingStats} />
+			<ChunkAccuracyGraph typingStats={typingStats} />
 		</div>
 	);
 };

--- a/web/src/utils/datetime.ts
+++ b/web/src/utils/datetime.ts
@@ -1,0 +1,20 @@
+export function convertTimestampsToISO(obj: any): any {
+	if (typeof obj === 'number') {
+		return new Date(obj).toISOString();
+	} else if (Array.isArray(obj)) {
+		return obj.map(convertTimestampsToISO);
+	} else if (typeof obj === 'object' && obj !== null) {
+		const newObj: { [key: string]: any } = {};
+		for (const key in obj) {
+			if (obj.hasOwnProperty(key)) {
+				if (typeof obj[key] === 'number' && key.toLowerCase().includes('timestamp')) {
+					newObj[key] = new Date(obj[key]).toISOString();
+				} else {
+					newObj[key] = convertTimestampsToISO(obj[key]); // Recurse without key check
+				}
+			}
+		}
+		return newObj;
+	}
+	return obj;
+}

--- a/web/src/utils/datetime.ts
+++ b/web/src/utils/datetime.ts
@@ -7,10 +7,10 @@ export function convertTimestampsToISO(obj: any): any {
 		const newObj: { [key: string]: any } = {};
 		for (const key in obj) {
 			if (obj.hasOwnProperty(key)) {
-				if (typeof obj[key] === 'number' && key.toLowerCase().includes('timestamp')) {
-					newObj[key] = new Date(obj[key]).toISOString();
+				if ((key.toLowerCase().includes('timestamp')) || (typeof obj[key] === 'object' && obj[key] !== null)) {
+					newObj[key] = convertTimestampsToISO(obj[key]);
 				} else {
-					newObj[key] = convertTimestampsToISO(obj[key]); // Recurse without key check
+					newObj[key] = obj[key];
 				}
 			}
 		}


### PR DESCRIPTION
1. Implement auth in MacOS app
2. Send data from MacOS app to server through NextJS APIs
3. Read data from server to create a very basic graph of historical typing speed and accuracy (not very useful in the current form)

Note: We had to increase the minimum supported MacOS version.