### PR TITLE
web: Fix npm build errors

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -10,7 +10,12 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.config({
+    extends: ["next/core-web-vitals", "next/typescript"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": "warn",
+    },
+  })
 ];
 
 export default eslintConfig;

--- a/web/src/utils/datetime.ts
+++ b/web/src/utils/datetime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export function convertTimestampsToISO(obj: any): any {
 	if (typeof obj === 'number') {
 		return new Date(obj).toISOString();
@@ -18,3 +19,4 @@ export function convertTimestampsToISO(obj: any): any {
 	}
 	return obj;
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
NPM build errors fixed by doing the following:
1. disabled the unused vars rule (it will only show them as warnings)
2. Since the convertTimestampsToISO function in datetime.ts is specifically make to handle all data types, made it an exception for eslint.