### PR TITLE
web: Improved the stats that are shown

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "typing-analyst-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typing-analyst-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.47.10",
         "axios": "^1.7.9",
         "chart.js": "^4.4.7",
+        "chartjs-adapter-date-fns": "^3.0.0",
+        "date-fns": "^4.1.0",
         "next": "15.1.3",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
@@ -1794,6 +1796,16 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=2.8.0",
+        "date-fns": ">=2.0.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2006,6 +2018,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typing-analyst-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
@@ -12,6 +12,8 @@
     "@supabase/supabase-js": "^2.47.10",
     "axios": "^1.7.9",
     "chart.js": "^4.4.7",
+    "chartjs-adapter-date-fns": "^3.0.0",
+    "date-fns": "^4.1.0",
     "next": "15.1.3",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",

--- a/web/src/app/api/typing-stats/route.ts
+++ b/web/src/app/api/typing-stats/route.ts
@@ -69,7 +69,10 @@ export async function GET(request: Request) {
 		const { data, error } = await supabase
 			.from('typing_stats')
 			.select('*')
-			.eq('user_id', user.id);
+			.eq('user_id', user.id)
+			.order('start_timestamp', { ascending: false })
+			.limit(1000);
+
 
 		if (error) {
 			console.error('Supabase error:', error);

--- a/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
+++ b/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
@@ -5,7 +5,6 @@ import { Chart } from "chart.js";
 import 'chart.js/auto';
 import { TimeScale } from "chart.js";
 import 'chartjs-adapter-date-fns';
-import { enUS } from 'date-fns/locale';
 import { TypingStat } from "./page";
 
 Chart.register(TimeScale);

--- a/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
+++ b/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
@@ -2,19 +2,26 @@
 
 import { Line } from "react-chartjs-2";
 import { Chart } from "chart.js";
+import 'chart.js/auto';
+import { TimeScale } from "chart.js";
+import 'chartjs-adapter-date-fns';
+import { enUS } from 'date-fns/locale';
 import { TypingStat } from "./page";
+
+Chart.register(TimeScale);
 
 const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttributes<HTMLDivElement>> = ({ typingStats, ...props }) => {
 	const primaryColor = window.getComputedStyle(document.documentElement).getPropertyValue('--primary');
 
 	const getAccuracyDataFromTypingStats = (typingStats: TypingStat[]) => {
 		const statsByDay = typingStats.reduce((acc, stat) => {
-			const date = new Date(stat.start_timestamp).toLocaleDateString();
+			const date = new Date(stat.start_timestamp);
+			const dateKey = date.toISOString().split('T')[0];
 			const accuracy = stat.chunk_stats.accuracy;
-			if (!acc[date]) {
-				acc[date] = [];
+			if (!acc[dateKey]) {
+				acc[dateKey] = [];
 			}
-			acc[date].push(accuracy);
+			acc[dateKey].push(accuracy);
 			return acc;
 		}, {} as Record<string, number[]>);
 
@@ -29,11 +36,14 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 		const stats = dates.map(date => calculateStats(statsByDay[date]));
 
 		return {
-			labels: dates,
+			labels: dates.map(date => new Date(date)),
 			datasets: [
 				{
 					label: 'Mean Accuracy',
-					data: stats.map(stat => stat.mean),
+					data: dates.map((date, i) => ({
+						x: new Date(date),
+						y: stats[i].mean
+					})),
 					fill: false,
 					borderColor: primaryColor,
 					backgroundColor: primaryColor + 20,
@@ -42,7 +52,10 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 				},
 				{
 					label: 'Accuracy Range (Upper)',
-					data: stats.map(stat => stat.mean + stat.stdDev),
+					data: dates.map((date, i) => ({
+						x: new Date(date),
+						y: stats[i].mean + stats[i].stdDev
+					})),
 					fill: 'stack',
 					borderColor: 'transparent',
 					backgroundColor: primaryColor + 40,
@@ -51,7 +64,10 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 				},
 				{
 					label: 'Accuracy Range (Lower)',
-					data: stats.map(stat => stat.mean - stat.stdDev),
+					data: dates.map((date, i) => ({
+						x: new Date(date),
+						y: stats[i].mean - stats[i].stdDev
+					})),
 					fill: '-2',
 					borderColor: 'transparent',
 					backgroundColor: primaryColor + 40,
@@ -65,6 +81,19 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 	const chartData = getAccuracyDataFromTypingStats(typingStats);
 	const options = {
 		scales: {
+			x: {
+				type: 'time' as const,
+				time: {
+					unit: 'day' as const,
+					displayFormats: {
+						day: 'MMM d'
+					}
+				},
+				ticks: {
+					source: 'auto' as const,
+					autoSkip: false
+				}
+			},
 			y: {
 				beginAtZero: true,
 			},
@@ -81,7 +110,7 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 						const lowerRange = allDatasets[2].data[context.dataIndex];
 
 						if (datasetIndex === 0 || datasetIndex === 1 || datasetIndex === 2) {
-							return `Mean Accuracy: ${meanAccuracy.toFixed(1)}% (${lowerRange.toFixed(1)}% - ${upperRange.toFixed(1)}%) [${chunksCount} chunks]`;
+							return `Mean Accuracy: ${meanAccuracy.y.toFixed(1)}% (${lowerRange.y.toFixed(1)}% - ${upperRange.y.toFixed(1)}%) [${chunksCount} chunks]`;
 						}
 					}
 				}

--- a/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
+++ b/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Line } from "react-chartjs-2";
-import { Chart } from "chart.js";
+import { Chart, TooltipItem, LegendItem, ChartDataset } from "chart.js";
 import 'chart.js/auto';
 import { TimeScale } from "chart.js";
 import 'chartjs-adapter-date-fns';
@@ -11,6 +11,8 @@ Chart.register(TimeScale);
 
 const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttributes<HTMLDivElement>> = ({ typingStats, ...props }) => {
 	const primaryColor = window.getComputedStyle(document.documentElement).getPropertyValue('--primary');
+
+	type CustomChartDataset = ChartDataset<'line'> & { chunksCount?: number[] };
 
 	const getAccuracyDataFromTypingStats = (typingStats: TypingStat[]) => {
 		const statsByDay = typingStats.reduce((acc, stat) => {
@@ -40,7 +42,7 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 				{
 					label: 'Mean Accuracy',
 					data: dates.map((date, i) => ({
-						x: new Date(date),
+						x: new Date(date).getTime(),
 						y: stats[i].mean
 					})),
 					fill: false,
@@ -48,11 +50,11 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 					backgroundColor: primaryColor + 20,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
-				},
+				} as CustomChartDataset,
 				{
 					label: 'Accuracy Range (Upper)',
 					data: dates.map((date, i) => ({
-						x: new Date(date),
+						x: new Date(date).getTime(),
 						y: stats[i].mean + stats[i].stdDev
 					})),
 					fill: 'stack',
@@ -60,11 +62,11 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 					backgroundColor: primaryColor + 40,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
-				},
+				} as CustomChartDataset,
 				{
 					label: 'Accuracy Range (Lower)',
 					data: dates.map((date, i) => ({
-						x: new Date(date),
+						x: new Date(date).getTime(),
 						y: stats[i].mean - stats[i].stdDev
 					})),
 					fill: '-2',
@@ -72,7 +74,7 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 					backgroundColor: primaryColor + 40,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
-				},
+				} as CustomChartDataset,
 			],
 		}
 	};
@@ -100,13 +102,13 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 		plugins: {
 			tooltip: {
 				callbacks: {
-					label: (context: any) => {
-						const chunksCount = context.dataset.chunksCount[context.dataIndex];
+					label: (context: TooltipItem<'line'>) => {
+						const chunksCount = (context.dataset as CustomChartDataset).chunksCount?.[context.dataIndex];
 						const datasetIndex = context.datasetIndex;
 						const allDatasets = context.chart.data.datasets;
-						const meanAccuracy = allDatasets[0].data[context.dataIndex];
-						const upperRange = allDatasets[1].data[context.dataIndex];
-						const lowerRange = allDatasets[2].data[context.dataIndex];
+						const meanAccuracy = allDatasets[0].data[context.dataIndex] as unknown as { x: Date, y: number };
+						const upperRange = allDatasets[1].data[context.dataIndex] as unknown as { x: Date, y: number };
+						const lowerRange = allDatasets[2].data[context.dataIndex] as unknown as { x: Date, y: number };
 
 						if (datasetIndex === 0 || datasetIndex === 1 || datasetIndex === 2) {
 							return `Mean Accuracy: ${meanAccuracy.y.toFixed(1)}% (${lowerRange.y.toFixed(1)}% - ${upperRange.y.toFixed(1)}%) [${chunksCount} chunks]`;
@@ -116,8 +118,8 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 			},
 			legend: {
 				labels: {
-					filter: (item: any) => item.text !== 'Accuracy Range (Lower)',
-					generateLabels: (chart: any) => {
+					filter: (item: LegendItem) => item.text !== 'Accuracy Range (Lower)',
+					generateLabels: (chart: Chart) => {
 						const labels = Chart.defaults.plugins.legend.labels.generateLabels(chart)
 						return labels.map(label => {
 							if (label.text === 'Accuracy Range (Upper)') {

--- a/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
+++ b/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
@@ -6,11 +6,19 @@ import 'chart.js/auto';
 import { TimeScale } from "chart.js";
 import 'chartjs-adapter-date-fns';
 import { TypingStat } from "./page";
+import { useEffect, useState } from "react";
 
 Chart.register(TimeScale);
 
 const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttributes<HTMLDivElement>> = ({ typingStats, ...props }) => {
-	const primaryColor = window.getComputedStyle(document.documentElement).getPropertyValue('--primary');
+	const [graphColor, setGraphColor] = useState<string>('rgba(153, 102, 255, 1)');
+
+	useEffect(() => {
+		if (typeof window !== 'undefined') {
+			const color = window.getComputedStyle(document.documentElement).getPropertyValue('--primary');
+			setGraphColor(color);
+		}
+	}, []);
 
 	type CustomChartDataset = ChartDataset<'line'> & { chunksCount?: number[] };
 
@@ -46,8 +54,8 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 						y: stats[i].mean
 					})),
 					fill: false,
-					borderColor: primaryColor,
-					backgroundColor: primaryColor + 20,
+					borderColor: graphColor,
+					backgroundColor: graphColor + 20,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
 				} as CustomChartDataset,
@@ -59,7 +67,7 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 					})),
 					fill: 'stack',
 					borderColor: 'transparent',
-					backgroundColor: primaryColor + 40,
+					backgroundColor: graphColor + 40,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
 				} as CustomChartDataset,
@@ -71,7 +79,7 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 					})),
 					fill: '-2',
 					borderColor: 'transparent',
-					backgroundColor: primaryColor + 40,
+					backgroundColor: graphColor + 40,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
 				} as CustomChartDataset,

--- a/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
+++ b/web/src/app/typing-stats/ChunkAccuracyGraph.tsx
@@ -1,20 +1,66 @@
 "use client";
 
 import { Line } from "react-chartjs-2";
+import { Chart } from "chart.js";
 import { TypingStat } from "./page";
 
 const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttributes<HTMLDivElement>> = ({ typingStats, ...props }) => {
-	const getAccuracyDataFromTypingStats = (typingStats: TypingStat[]) => ({
-		labels: typingStats.map(stat => new Date(stat.start_timestamp).toLocaleTimeString()),
-		datasets: [
-			{
-				label: 'Accuracy',
-				data: typingStats.map(stat => stat.chunk_stats.accuracy),
-				borderColor: 'rgba(153, 102, 255, 1)',
-				backgroundColor: 'rgba(153, 102, 255, 0.2)',
-			},
-		],
-	});
+	const primaryColor = window.getComputedStyle(document.documentElement).getPropertyValue('--primary');
+
+	const getAccuracyDataFromTypingStats = (typingStats: TypingStat[]) => {
+		const statsByDay = typingStats.reduce((acc, stat) => {
+			const date = new Date(stat.start_timestamp).toLocaleDateString();
+			const accuracy = stat.chunk_stats.accuracy;
+			if (!acc[date]) {
+				acc[date] = [];
+			}
+			acc[date].push(accuracy);
+			return acc;
+		}, {} as Record<string, number[]>);
+
+		const calculateStats = (values: number[]) => {
+			const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
+			const variance = values.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / values.length;
+			const stdDev = Math.sqrt(variance);
+			return { mean, stdDev, count: values.length };
+		};
+
+		const dates = Object.keys(statsByDay).sort();
+		const stats = dates.map(date => calculateStats(statsByDay[date]));
+
+		return {
+			labels: dates,
+			datasets: [
+				{
+					label: 'Mean Accuracy',
+					data: stats.map(stat => stat.mean),
+					fill: false,
+					borderColor: primaryColor,
+					backgroundColor: primaryColor + 20,
+					tension: 0.1,
+					chunksCount: stats.map(stat => stat.count),
+				},
+				{
+					label: 'Accuracy Range (Upper)',
+					data: stats.map(stat => stat.mean + stat.stdDev),
+					fill: 'stack',
+					borderColor: 'transparent',
+					backgroundColor: primaryColor + 40,
+					tension: 0.1,
+					chunksCount: stats.map(stat => stat.count),
+				},
+				{
+					label: 'Accuracy Range (Lower)',
+					data: stats.map(stat => stat.mean - stat.stdDev),
+					fill: '-2',
+					borderColor: 'transparent',
+					backgroundColor: primaryColor + 40,
+					tension: 0.1,
+					chunksCount: stats.map(stat => stat.count),
+				},
+			],
+		}
+	};
 
 	const chartData = getAccuracyDataFromTypingStats(typingStats);
 	const options = {
@@ -23,10 +69,43 @@ const ChunkAccuracyGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAtt
 				beginAtZero: true,
 			},
 		},
+		plugins: {
+			tooltip: {
+				callbacks: {
+					label: (context: any) => {
+						const chunksCount = context.dataset.chunksCount[context.dataIndex];
+						const datasetIndex = context.datasetIndex;
+						const allDatasets = context.chart.data.datasets;
+						const meanAccuracy = allDatasets[0].data[context.dataIndex];
+						const upperRange = allDatasets[1].data[context.dataIndex];
+						const lowerRange = allDatasets[2].data[context.dataIndex];
+
+						if (datasetIndex === 0 || datasetIndex === 1 || datasetIndex === 2) {
+							return `Mean Accuracy: ${meanAccuracy.toFixed(1)}% (${lowerRange.toFixed(1)}% - ${upperRange.toFixed(1)}%) [${chunksCount} chunks]`;
+						}
+					}
+				}
+			},
+			legend: {
+				labels: {
+					filter: (item: any) => item.text !== 'Accuracy Range (Lower)',
+					generateLabels: (chart: any) => {
+						const labels = Chart.defaults.plugins.legend.labels.generateLabels(chart)
+						return labels.map(label => {
+							if (label.text === 'Accuracy Range (Upper)') {
+								label.text = 'Accuracy Variance (±1 StdDev)'
+							}
+							return label
+						})
+					}
+				}
+			}
+		}
 	};
+
 	return (
 		<div className='w-full' {...props}>
-			<h2>Accuracy</h2>
+			<h2>Accuracy by Day</h2>
 			<Line data={chartData} options={options} />
 		</div>
 	);

--- a/web/src/app/typing-stats/ChunkWPMGraph.tsx
+++ b/web/src/app/typing-stats/ChunkWPMGraph.tsx
@@ -5,7 +5,6 @@ import { Chart } from "chart.js";
 import 'chart.js/auto';
 import { TimeScale } from "chart.js";
 import 'chartjs-adapter-date-fns';
-import { enUS } from 'date-fns/locale';
 import { TypingStat } from "./page";
 
 Chart.register(TimeScale);

--- a/web/src/app/typing-stats/ChunkWPMGraph.tsx
+++ b/web/src/app/typing-stats/ChunkWPMGraph.tsx
@@ -19,10 +19,10 @@ const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttribut
 			const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
 			const variance = values.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / values.length;
 			const stdDev = Math.sqrt(variance);
-			return { mean, stdDev };
+			return { mean, stdDev, count: values.length };
 		};
 
-		const dates = Object.keys(statsByDay);
+		const dates = Object.keys(statsByDay).sort();
 		const stats = dates.map(date => calculateStats(statsByDay[date]));
 
 		return {
@@ -35,6 +35,7 @@ const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttribut
 					borderColor: 'rgba(75, 192, 192, 1)',
 					backgroundColor: 'rgba(75, 192, 192, 0.2)',
 					tension: 0.1,
+					chunksCount: stats.map(stat => stat.count),
 				},
 				{
 					label: 'WPM Range (±1 StdDev)',
@@ -43,6 +44,7 @@ const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttribut
 					borderColor: 'transparent',
 					backgroundColor: 'rgba(75, 192, 192, 0.1)',
 					tension: 0.1,
+					chunksCount: stats.map(stat => stat.count),
 				},
 			],
 		}
@@ -59,10 +61,11 @@ const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttribut
 			tooltip: {
 				callbacks: {
 					label: (context: any) => {
+						const chunksCount = context.dataset.chunksCount[context.dataIndex];
 						if (context.datasetIndex === 0) {
-							return `Mean WPM: ${context.raw.toFixed(1)}`;
+							return `Mean WPM: ${context.raw.toFixed(1)} (${chunksCount} chunks)`;
 						} else {
-							return `Standard Deviation: ±${context.raw.toFixed(1)}`;
+							return `Standard Deviation: ±${context.raw.toFixed(1)} (${chunksCount} chunks)`;
 						}
 					}
 				}

--- a/web/src/app/typing-stats/ChunkWPMGraph.tsx
+++ b/web/src/app/typing-stats/ChunkWPMGraph.tsx
@@ -6,11 +6,19 @@ import 'chart.js/auto';
 import { TimeScale } from "chart.js";
 import 'chartjs-adapter-date-fns';
 import { TypingStat } from "./page";
+import { useEffect, useState } from "react";
 
 Chart.register(TimeScale);
 
 const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttributes<HTMLDivElement>> = ({ typingStats, ...props }) => {
-	const secondaryColor = window.getComputedStyle(document.documentElement).getPropertyValue('--secondary');
+	const [graphColor, setGraphColor] = useState<string>('rgba(75, 192, 192, 1)');
+
+	useEffect(() => {
+		if (typeof window !== 'undefined') {
+			const color = window.getComputedStyle(document.documentElement).getPropertyValue('--secondary');
+			setGraphColor(color);
+		}
+	}, []);
 
 	type CustomChartDataset = ChartDataset<'line'> & { chunksCount?: number[] };
 
@@ -46,8 +54,8 @@ const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttribut
 						y: stats[i].mean
 					})),
 					fill: false,
-					borderColor: secondaryColor,
-					backgroundColor: secondaryColor + 20,
+					borderColor: graphColor,
+					backgroundColor: graphColor + 20,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
 				} as CustomChartDataset,
@@ -59,7 +67,7 @@ const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttribut
 					})),
 					fill: 'stack',
 					borderColor: 'transparent',
-					backgroundColor: secondaryColor + 40,
+					backgroundColor: graphColor + 40,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
 				} as CustomChartDataset,
@@ -71,7 +79,7 @@ const ChunkWPMGraph: React.FC<{ typingStats: TypingStat[] } & React.HTMLAttribut
 					})),
 					fill: '-2',
 					borderColor: 'transparent',
-					backgroundColor: secondaryColor + 40,
+					backgroundColor: graphColor + 40,
 					tension: 0.1,
 					chunksCount: stats.map(stat => stat.count),
 				} as CustomChartDataset,

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -86,7 +86,7 @@ const TypingStatsPage: React.FC = () => {
 		<div className="flex flex-col items-center justify-items-center min-h-screen gap-12 sm:px-20 sm:py-4 font-[family-name:var(--font-space-mono-regular)] bg-background">
 			<div className='w-3/4 flex flex-col items-center justify-center gap-4'>
 				<h1 className="text-center text-xl w-full">Typing Statistics</h1>
-				<caption className='text-center w-full'>For the {eligibleChunks.length} chunks (out of {typingStats.length} total) that have more than 5 words</caption>
+				<p className='text-center w-full'>For the {eligibleChunks.length} chunks (out of {typingStats.length} total) that have more than 5 words</p>
 			</div>
 			<section className='flex justify-evenly w-full flex-wrap gap-6'>
 				<BigNumber

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -38,6 +38,7 @@ export type PerSecondData = {
 
 const TypingStatsPage: React.FC = () => {
 	const [typingStats, setTypingStats] = useState<TypingStat[]>([]);
+	const [eligibleChunks, setEligibleChunks] = useState<TypingStat[]>([]);
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -76,7 +77,9 @@ const TypingStatsPage: React.FC = () => {
 		fetchTypingStats();
 	}, []);
 
-	const eligibleChunks = typingStats.filter(stat => stat.chunk_stats.totalWords >= 5);
+	useEffect(() => {
+		setEligibleChunks(typingStats.filter(stat => stat.chunk_stats.totalWords >= 5));
+	}, [typingStats]);
 
 	if (error) {
 		return <div>Error: {error}</div>;
@@ -100,7 +103,6 @@ const TypingStatsPage: React.FC = () => {
 						const chunkEnd = new Date(stat.end_timestamp);
 						const chunkDurationMin = (chunkEnd.getTime() - chunkStart.getTime()) / (1000 * 60)
 						const chunkSpeed = stat.chunk_stats.totalWords / chunkDurationMin
-						// console.log(`chunkSpeed: ${chunkSpeed}`)
 						return acc + chunkSpeed;
 					}, 0) / eligibleChunks.length || 0}
 					units="WPM"


### PR DESCRIPTION
The stats shown earlier were completely unreadable. They were the wpm and accuracy numbers for every single chunk that was captured for the user (well, only the last 1000).

Now, the stats that are shown are actually usable. However, there is still this problem that it can only fetch the last 1000 chunks only, but the stats for these 1000 chunks are actually usable.