### PR TITLE
web: add refresh token functionality for client side API calls.

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typing-analyst-web",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typing-analyst-web",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@supabase/supabase-js": "^2.47.10",
         "@vercel/analytics": "^1.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typing-analyst-web",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -45,9 +45,9 @@ const TypingStatsPage: React.FC = () => {
 
 	useEffect(() => {
 		const fetchTypingStatsSummary = async () => {
-			const { data, error } = await ClientApiHelper.get('/api/typing-stats/summary');
-			if (error) {
-				setError(error.message);
+			const { data, error } = await ClientApiHelper.get<{ data: SummaryStats[] }>('/api/typing-stats/summary');
+			if (error || !data) {
+				setError(error?.message ?? "No summary statistics received.");
 				return;
 			}
 			setSummary(data.data[0]);
@@ -58,9 +58,9 @@ const TypingStatsPage: React.FC = () => {
 
 	useEffect(() => {
 		const fetchTypingStatsTimelineByDay = async () => {
-			const { data, error } = await ClientApiHelper.get('/api/typing-stats/daily');
-			if (error) {
-				setError(error.message);
+			const { data, error } = await ClientApiHelper.get<{ data: DailyStats[] }>('/api/typing-stats/daily');
+			if (error || !data) {
+				setError(error?.message ?? "No daily typing statistics data received.");
 				return;
 			}
 			setDailyStat(data.data);

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -45,7 +45,7 @@ const TypingStatsPage: React.FC = () => {
 
 	useEffect(() => {
 		const fetchTypingStatsSummary = async () => {
-			const { data, error } = await ClientApiHelper.get<{ data: SummaryStats[] }>('/api/typing-stats/summary');
+			const { data, error } = await ClientApiHelper.get<{ data: SummaryStats[] }>('/api/typing-stats/summary', true);
 			if (error || !data) {
 				setError(error?.message ?? "No summary statistics received.");
 				return;
@@ -58,7 +58,7 @@ const TypingStatsPage: React.FC = () => {
 
 	useEffect(() => {
 		const fetchTypingStatsTimelineByDay = async () => {
-			const { data, error } = await ClientApiHelper.get<{ data: DailyStats[] }>('/api/typing-stats/daily');
+			const { data, error } = await ClientApiHelper.get<{ data: DailyStats[] }>('/api/typing-stats/daily', true);
 			if (error || !data) {
 				setError(error?.message ?? "No daily typing statistics data received.");
 				return;

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -46,7 +46,6 @@ const TypingStatsPage: React.FC = () => {
 	useEffect(() => {
 		const fetchTypingStatsSummary = async () => {
 			const { data, error } = await ClientApiHelper.get('/api/typing-stats/summary');
-			console.log({ data, error });
 			if (error) {
 				setError(error.message);
 				return;
@@ -60,7 +59,6 @@ const TypingStatsPage: React.FC = () => {
 	useEffect(() => {
 		const fetchTypingStatsTimelineByDay = async () => {
 			const { data, error } = await ClientApiHelper.get('/api/typing-stats/daily');
-			console.log({ data, error });
 			if (error) {
 				setError(error.message);
 				return;

--- a/web/src/app/typing-stats/page.tsx
+++ b/web/src/app/typing-stats/page.tsx
@@ -6,6 +6,7 @@ import ChunkWPMGraph from './ChunkWPMGraph';
 import ChunkAccuracyGraph from './ChunkAccuracyGraph';
 import BigNumber from './BigNumber';
 import { DailyStats, SummaryStats } from '../../../types/query.types';
+import { ClientApiHelper } from '@/utils/apiUtils';
 
 export type TypingStat = {
 	start_timestamp: string;
@@ -44,35 +45,12 @@ const TypingStatsPage: React.FC = () => {
 
 	useEffect(() => {
 		const fetchTypingStatsSummary = async () => {
-			const userId = localStorage.getItem('userId');
-
-			if (!userId) {
-				setError('Unauthorized');
-				window.location.href = '/login';
+			const { data, error } = await ClientApiHelper.get('/api/typing-stats/summary');
+			console.log({ data, error });
+			if (error) {
+				setError(error.message);
 				return;
 			}
-
-			const response = await fetch('/api/typing-stats/summary?nonce=' + Math.random(), {
-				method: 'GET',
-				headers: {
-					'Content-Type': 'application/json',
-					'Cache-Control': 'no-store',
-				},
-			});
-
-			if (!response.ok) {
-				const errorData = await response.json();
-				if (response.status === 401) {
-					setError('Unauthorized');
-					console.error('Unauthorized: redirecting to login');
-					window.location.href = '/login';
-					return;
-				}
-				setError(errorData.error);
-				return;
-			}
-
-			const data: { data: SummaryStats[] } = await response.json();
 			setSummary(data.data[0]);
 		};
 
@@ -81,36 +59,12 @@ const TypingStatsPage: React.FC = () => {
 
 	useEffect(() => {
 		const fetchTypingStatsTimelineByDay = async () => {
-			const userId = localStorage.getItem('userId');
-
-			if (!userId) {
-				setError('Unauthorized');
-				window.location.href = '/login';
+			const { data, error } = await ClientApiHelper.get('/api/typing-stats/daily');
+			console.log({ data, error });
+			if (error) {
+				setError(error.message);
 				return;
 			}
-
-			const response = await fetch('/api/typing-stats/daily?nonce=' + Math.random(), {
-				method: 'GET',
-				headers: {
-					'Content-Type': 'application/json',
-					'Cache-Control': 'no-store',
-				},
-			});
-
-			if (!response.ok) {
-				const errorData = await response.json();
-				if (response.status === 401) {
-					setError('Unauthorized');
-					console.error('Unauthorized: redirecting to login');
-					window.location.href = '/login';
-					return;
-				}
-				setError(errorData.error);
-				return;
-			}
-
-			const data: { data: DailyStats[] } = await response.json();
-			console.log(data.data);
 			setDailyStat(data.data);
 		};
 

--- a/web/src/utils/apiUtils.ts
+++ b/web/src/utils/apiUtils.ts
@@ -40,11 +40,11 @@ export class ClientApiHelper {
 		} catch (error) {
 			if (axios.isAxiosError(error) && error.response) {
 				if (error.response.status === 401) {
-					console.error('Unauthorized: trying to refresh token');
+					console.error('Unauthorized: trying to refresh token', error);
 					try {
 						const refreshResponse = await axios.post('/api/auth/refresh');
 						if (!refreshResponse.data) {
-							console.error('Failed to refresh token: redirecting to login');
+							console.error('Failed to refresh token: redirecting to login', refreshResponse);
 							window.location.href = '/login';
 							return { data: null, error: new Error('Unauthorized', { cause: 'Failed to refresh token' }) };
 						}
@@ -56,7 +56,7 @@ export class ClientApiHelper {
 
 						return { data: retryResponse.data, error: null };
 					} catch (retryError) {
-						console.error('Failed to fetch data after refreshing token: redirecting to login');
+						console.error('Failed to fetch data after refreshing token: redirecting to login', retryError);
 						window.location.href = '/login';
 						return { data: null, error: new Error('Unauthorized', { cause: 'Failed to fetch data after token refresh' }) };
 					}

--- a/web/src/utils/apiUtils.ts
+++ b/web/src/utils/apiUtils.ts
@@ -1,0 +1,71 @@
+import axios from "axios";
+
+export function addParamsToUrl(url: string, params: Record<string, string>): string {
+	const baseUrl = url.startsWith('http') ? url : `${window.location.origin}${url}`;
+	const urlObj = new URL(baseUrl);
+	Object.entries(params).forEach(([key, value]) => {
+		urlObj.searchParams.append(key, value);
+	});
+	return urlObj.toString();
+}
+
+export class ClientApiHelper {
+	headers = {
+		'Content-Type': 'application/json',
+	};
+
+	static async post(url: string, data: any) {
+		return axios.post(url, data);
+	}
+
+	static async get(url: string, noCache = false): Promise<{ data: any, error: Error | null }> {
+		const userId = localStorage.getItem('userId');
+		const endPointUrl = addParamsToUrl(url, noCache ? { 'nonce': Math.random().toString() } : {});
+		const headers = {
+			'Content-Type': 'application/json',
+			...(noCache ? { 'Cache-Control': 'no-store' } : {}),
+		}
+
+		if (!userId) {
+			window.location.href = '/login';
+			return { data: null, error: new Error('Unauthorized', { cause: 'No user found.' }) };
+		}
+
+		try {
+			const response = await axios.get(endPointUrl, {
+				headers: headers,
+			});
+
+			return { data: response.data, error: null };
+		} catch (error) {
+			if (axios.isAxiosError(error) && error.response) {
+				if (error.response.status === 401) {
+					console.error('Unauthorized: trying to refresh token');
+					try {
+						const refreshResponse = await axios.post('/api/auth/refresh');
+						if (!refreshResponse.data) {
+							console.error('Failed to refresh token: redirecting to login');
+							window.location.href = '/login';
+							return { data: null, error: new Error('Unauthorized', { cause: 'Failed to refresh token' }) };
+						}
+
+						// try to fetch the data again
+						const retryResponse = await axios.get(endPointUrl, {
+							headers: headers,
+						});
+
+						return { data: retryResponse.data, error: null };
+					} catch (retryError) {
+						console.error('Failed to fetch data after refreshing token: redirecting to login');
+						window.location.href = '/login';
+						return { data: null, error: new Error('Unauthorized', { cause: 'Failed to fetch data after token refresh' }) };
+					}
+				}
+				console.error('An error occurred while fetching data:', error);
+				return { data: null, error: new Error(error.response.data.error || 'An error occurred') };
+			}
+			console.error('An unexpected error occurred:', error);
+			return { data: null, error: new Error('An unexpected error occurred') };
+		}
+	}
+}

--- a/web/src/utils/apiUtils.ts
+++ b/web/src/utils/apiUtils.ts
@@ -18,7 +18,7 @@ export class ClientApiHelper {
 		return axios.post(url, data);
 	}
 
-	static async get(url: string, noCache = false): Promise<{ data: any, error: Error | null }> {
+	static async get<T>(url: string, noCache = false): Promise<{ data: T | null, error: Error | null }> {
 		const userId = localStorage.getItem('userId');
 		const endPointUrl = addParamsToUrl(url, noCache ? { 'nonce': Math.random().toString() } : {});
 		const headers = {

--- a/web/src/utils/apiUtils.ts
+++ b/web/src/utils/apiUtils.ts
@@ -10,7 +10,7 @@ export function addParamsToUrl(url: string, params: Record<string, string>): str
 }
 
 export class ClientApiHelper {
-	private static async handleRequest<T>(method: 'get' | 'post', url: string, data?: any, noCache = false): Promise<{ data: T | null, error: Error | null }> {
+	private static async handleRequest<T, U>(method: 'get' | 'post', url: string, data?: U, noCache = false): Promise<{ data: T | null, error: Error | null }> {
 		const userId = localStorage.getItem('userId');
 		const endPointUrl = addParamsToUrl(url, noCache ? { 'nonce': Math.random().toString() } : {});
 		const headers = {
@@ -68,10 +68,10 @@ export class ClientApiHelper {
 	}
 
 	static async post<T, U>(url: string, data: T, noCache = false): Promise<{ data: U | null, error: Error | null }> {
-		return this.handleRequest<U>('post', url, data, noCache);
+		return this.handleRequest<U, T>('post', url, data, noCache);
 	}
 
 	static async get<T>(url: string, noCache = false): Promise<{ data: T | null, error: Error | null }> {
-		return this.handleRequest<T>('get', url, undefined, noCache);
+		return this.handleRequest<T, never>('get', url, undefined, noCache);
 	}
 }


### PR DESCRIPTION
This pull request contains the following changes:

1. **ChunkAccuracyGraph.tsx**:
    - Converts `mean` and `stdDev` values to numbers for accuracy calculations.
    - Adds a formatted date to tooltips.
    - Refines tooltip label logic to display mean accuracy and accuracy ranges separately.

2. **ChunkWPMGraph.tsx**:
    - Adds a formatted date to tooltips.
    - Refines tooltip label logic to display mean speed and speed ranges separately.

3. **typing-stats/page.tsx**:
    - Replaces direct fetch API calls with `ClientApiHelper` for fetching typing statistics.
    - Removes user authorization checks and login redirection logic.

4. **apiUtils.ts** (new file):
    - Introduces utility functions for handling API requests, including adding parameters to URLs and managing GET/POST requests with caching options.

5. **package.json** and **package-lock.json**:
    - Updates the version from `0.4.0` to `0.4.1`.

These changes improve the accuracy and speed data handling in the typing statistics graphs and refactor API request handling for better maintainability.